### PR TITLE
fix comment typo

### DIFF
--- a/tests/test_0_research.py
+++ b/tests/test_0_research.py
@@ -219,7 +219,7 @@ class Company(Network):
         """
         For systems with static relationships, you can define them in the constructor.
 
-        For dynamic systems, you can use actor.receivers(MessageClass, [*MessageClasses]) to
+        For dynamic systems, you can use network.receivers(MessageClass, [*MessageClasses]) to
         get a list of actors in the network that can receive all the passed MessageClasses.
         """
         for a, b in combinations(actors, 2):


### PR DESCRIPTION
at some point I remember reading this comment and presuming that somehow the `network_context` would automatically edges between actors in a network scope. that's obviously not the case, but I think this change would help correct that notion for others